### PR TITLE
Expand contact form with additional element types

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -32,10 +32,32 @@
 <label for="email">Email:</label>
 <input type="email" id="email" name="email" required>
 
+<label for="subject">Subject:</label>
+<select id="subject" name="subject" required>
+<option value="">-- Select a topic --</option>
+<option value="feedback">Feedback</option>
+<option value="support">Support</option>
+<option value="partnership">Partnership</option>
+<option value="other">Other</option>
+</select>
+
+<fieldset>
+<legend>Preferred contact method:</legend>
+<label><input type="radio" name="contact-method" value="email" checked> Email</label>
+<label><input type="radio" name="contact-method" value="phone"> Phone</label>
+<label><input type="radio" name="contact-method" value="none"> No reply needed</label>
+</fieldset>
+
+<label>
+<input type="checkbox" id="newsletter" name="newsletter" value="yes">
+Subscribe to wellness tips newsletter
+</label>
+
 <label for="message">Message:</label>
 <textarea id="message" name="message" required></textarea>
 
 <button type="submit">Send</button>
+<button type="reset">Reset</button>
 </form>
 
 </section>


### PR DESCRIPTION
## Summary
- Adds a `<select>` subject dropdown, radio buttons for preferred contact method, and a newsletter checkbox to the contact form
- Adds a reset button alongside the existing submit button
- Brings the form to 5+ distinct element types, satisfying the rubric requirement of 3+ different element types

Closes #10
Closes #14

## Test plan
- [ ] Open `contact.html` in a browser
- [ ] Confirm dropdown, radio buttons, and checkbox render and are interactive
- [ ] Confirm reset button clears all fields
- [ ] Confirm submit still works with required-field validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)